### PR TITLE
Add source map support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   "homepage": "https://github.com/Banno/polymer-webapck-loader#readme",
   "dependencies": {
     "dom5": "^2.3.0",
+    "espree": "^3.4.3",
     "html-minifier": "^3.4.3",
     "loader-utils": "^1.1.0",
     "parse5": "^3.0.2",
     "parse5-utils": "^2.0.0",
+    "source-map": "^0.5.6",
     "webpack": "^2.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,11 +26,21 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
 acorn@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
-acorn@^5.0.0:
+acorn@^5.0.0, acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
@@ -539,6 +549,13 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+espree@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
+  dependencies:
+    acorn "^5.0.1"
+    acorn-jsx "^3.0.0"
 
 events@^1.0.0:
   version "1.1.1"
@@ -1545,7 +1562,7 @@ source-list-map@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.1.2.tgz#9889019d1024cce55cdc069498337ef6186a11a1"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 


### PR DESCRIPTION
Fixes #6 

Creates identity source maps for every polymer file. Eventually we may want to read incoming source maps, but we first need to determine if that even makes sense. While it is possible for an inline script tag to contain a source map as a dataUrl, in practice I've never seen this (though I did handle this case in polymer-bundler).

To test this PR, add `devtool: 'inline-source-map'` to the webpack config object. When served in a browser, the full original HTML source should be available and breakpoints inside script tags should work as expected.